### PR TITLE
Cleaning up Holder

### DIFF
--- a/code/GridFieldPageHolder.php
+++ b/code/GridFieldPageHolder.php
@@ -6,11 +6,9 @@ class GridFieldPageHolder extends Page {
 	private static $default_child = "GridFieldPage";
 	private static $add_default_gridfield = true;
 	
-//	static $extensions = array("ExcludeChildren");
-//	static $excluded_children = array('GridFieldPage');
-	
 	public static function setAddDefaultGridField(Boolean $val){
-		self::$add_default_gridfield = $val;
+		Deprecation::notice('1.0', 'setAddDefaultGridField is deprecated please use Config instead');
+		self::config()->update('add_default_gridfield', $val);
 	}
      
 	public function getCMSFields() {
@@ -18,10 +16,8 @@ class GridFieldPageHolder extends Page {
 		
 		// GridFieldPage
 		$fields->addFieldToTab('Root.Subpages', new HeaderField('GridfieldPages', 'Subpages of this page'));
-//		$fields->addFieldToTab('Root.Subpages', 
-//				new NumericField('ItemsPerPage', 'Paginate subpages per (0 for no pagination)'));
 		
-		if( self::$add_default_gridfield ){
+		if( self::config()->get('add_default_gridfield') ){
 			$gridFieldConfig = GridFieldConfig::create()->addComponents(
 				new GridFieldToolbarHeader(),
 				new GridFieldAddNewSiteTreeItemButton('toolbar-header-right'),
@@ -35,7 +31,6 @@ class GridFieldPageHolder extends Page {
 			$dataColumns->setDisplayFields(array(
 				'Title' => 'Title',
 				'URLSegment'=> 'URL',
-				//'formattedPublishDate' => 'Publish date',
 				'getStatus' => 'Status',
 				'LastEdited' => 'Changed',
 			));
@@ -43,12 +38,11 @@ class GridFieldPageHolder extends Page {
 			// include both live and stage versions of pages
 			$pages = $this->AllChildrenIncludingDeleted();
 
-			// use gridfield as normal;
-			$gridField = new GridField("Subpages", "Manage ".self::$default_child."s", 
+			// use gridfield as normal
+			$gridField = new GridField("Subpages", "Manage " . singleton($this->defaultChild())->i18n_plural_name(),
 				$pages, $gridFieldConfig);
 			
-			$gridField->setModelClass(self::$default_child);
-			//$gridField->setModelClass("GridFieldPage"); // prevents "GridField doesn't have a modelClassName" error
+			$gridField->setModelClass($this->defaultChild());
 			
 			$fields->addFieldToTab("Root.Subpages", $gridField);
 		}
@@ -56,45 +50,7 @@ class GridFieldPageHolder extends Page {
 		return $fields;
 	}
 	
-//	public function SortedChildren(){ 
-//		return $this->Children();
-//		
-//		//return $this->Children->sort('Date');
-////		// $children will be a DataObjectSet 
-////		$children = $this->Children();
-////
-////		if( !$children ) 
-////		return null; // no children, nothing to work with
-////
-////		// optionally: sort on some other field, like Date (override from subclass)
-////		//$children->sort('Date', 'DESC');
-////		
-////		// M: gridnews
-////		if($this->ItemsPerPage && $this->ItemsPerPage > 0) {
-////			$ctrlr = Controller::curr();
-////			$children = new PaginatedList($children, $ctrlr->request);
-////			$children->setPageLength($this->ItemsPerPage);
-////		}
-////		// M: END gridnews
-////
-////		// return sorted set 
-////		return $children; 
-//	}
-	
-	
 }
  
 class GridFieldPageHolder_Controller extends Page_Controller {
-	
-	// redirect this page to its first child page (better to implement on link() in Model)
-//	public function index(){
-//		if($children = $this->Children()){
-//			$children->sort('Date','DESC');
-//			if($firstChild = $children->limit(1)){
-//				$firstChild1 = $firstChild[0];
-//				$this->redirect($firstChild1->Link());
-//			}
-//		}
-//	}
-	
 }


### PR DESCRIPTION
- Removed commented code (that's what VCS is for)
- Used `Config` system for private static vars
- Used in-built function for pluralisation of model names
- Deprecated `setAddDefaultGridField`
