### PR TITLE
Code standards: Bringing recently merged code back up to helpfulrobot's high standards.

### DIFF
--- a/code/GridFieldPage.php
+++ b/code/GridFieldPage.php
@@ -6,31 +6,33 @@ require_once(__DIR__ . '/GridFieldPageTrait.php');
  * Extend this object to implement grid field capability for Page objects. Optionally, you can apply the
  * GridFieldPageExtension instead.
  *
- * @author	Michael van Schaik, mic@restruct.nl
- * @since	2017-04-26
+ * @author   Michael van Schaik, mic@restruct.nl
+ * @since    2017-04-26
  */
 
-class GridFieldPage extends Page {
-	
-	private static $can_be_root = false;
-	private static $allowed_children = "none";
-	
-	private static $defaults = array ( 
-	   'ShowInMenus' => false,
-	);
-	
-	private static $searchable_fields = array(
-		'Title', 'MenuTitle'
-	);
-	
-	private static $summary_fields = array(
-		"Title", 'MenuTitle'
-	);
+class GridFieldPage extends Page
+{
 
-	use GridFieldPageTrait;
+    private static $can_be_root = false;
+    private static $allowed_children = "none";
+
+    private static $defaults = array(
+        'ShowInMenus' => false,
+    );
+
+    private static $searchable_fields = array(
+        'Title', 'MenuTitle'
+    );
+
+    private static $summary_fields = array(
+        "Title", 'MenuTitle'
+    );
+
+    use GridFieldPageTrait;
 
 }
- 
+
 class GridFieldPage_Controller extends Page_Controller
 {
+
 }

--- a/code/GridFieldPageHolder.php
+++ b/code/GridFieldPageHolder.php
@@ -5,24 +5,24 @@ class GridFieldPageHolder extends Page
 
     private static $allowed_children = array('*GridFieldPage');
     private static $default_child = "GridFieldPage";
-    
+
     private static $add_default_gridfield = true;
     private static $apply_sortable = true;
     private static $subpage_tab = "Root.Subpages";
     private static $gridfield_title = "Manage Subpages";
-    
-    public static function setAddDefaultGridField(Boolean $val)
+
+    public static function setAddDefaultGridField($val)
     {
         Deprecation::notice('1.0', 'setAddDefaultGridField is deprecated please use Config instead');
-        self::config()->update('add_default_gridfield', $val);
+        self::config()->update('add_default_gridfield', (bool) $val);
     }
-     
+
     public function getCMSFields()
     {
         $fields = parent::getCMSFields();
-        
+
         $PageTab = Config::inst()->get($this->owner->className, 'subpage_tab');
-        
+
         // GridFieldPage
         if (Config::inst()->get($this->owner->className, 'add_default_gridfield')) {
             $gridFieldConfig = GridFieldConfig::create()->addComponents(
@@ -50,7 +50,7 @@ class GridFieldPageHolder extends Page
                 'getStatus' => 'Status',
                 //'LastEdited' => 'Changed',
             ));
-            
+
             // include both live and stage versions of pages
             // use gridfield as normal
             $gridField = new GridField("Subpages",
@@ -59,16 +59,16 @@ class GridFieldPageHolder extends Page
                     //SiteTree::get()->filter('ParentID', $this->ID),
                     $this->AllChildrenIncludingDeleted(),
                     $gridFieldConfig);
-            
+
             $gridField->setModelClass($this->defaultChild());
-            
+
             $fields->addFieldToTab($PageTab, $gridField);
         }
-        
+
         return $fields;
     }
-    
-    // @TODO: A page still needs to be published for the sortorder to be updated, 
+
+    // @TODO: A page still needs to be published for the sortorder to be updated,
     // we need some kind of warning/info to inform CMS users about this
 //	public function SortedChildren(){
 //		//return DataObject::get($this->defaultChild(), 'ParentID = '.$this->ID);
@@ -90,7 +90,7 @@ class GridFieldPageHolder extends Page
 //		return BlogGridPage::get()->filter('ParentID', $this->ID)->sort('Date DESC')->limit($amount);
 //	}
 }
- 
+
 class GridFieldPageHolder_Controller extends Page_Controller
 {
 }

--- a/code/GridFieldPageTrait.php
+++ b/code/GridFieldPageTrait.php
@@ -4,120 +4,124 @@
  * extending the GridFieldPage class or applying the GridFieldPageExtension to your page via SilverStripe API:
  * https://docs.silverstripe.org/en/3/developer_guides/extending/extensions/
  *
- * @author	Michael van Schaik, mic@restruct.nl
- * @author	Patrick Nelson, pat@catchyour.com
- * @since	2017-04-26
+ * @author   Michael van Schaik, mic@restruct.nl
+ * @author   Patrick Nelson, pat@catchyour.com
+ * @since    2017-04-26
  */
 
-trait GridFieldPageTrait {
+trait GridFieldPageTrait
+{
 
-	/**
-	 * Page instance will vary depending on context (i.e. is this trait on page or page extension?)
-	 *
-	 * @return GridFieldPage
-	 */
-	private function getGridFieldPage() {
-		if ($this instanceof GridFieldPageExtension) {
-			return $this->getOwner();
+    /**
+     * Page instance will vary depending on context (i.e. is this trait on page or page extension?)
+     *
+     * @return GridFieldPage
+     */
+    private function getGridFieldPage()
+    {
+        if ($this instanceof GridFieldPageExtension) {
+            return $this->getOwner();
 
-		} elseif ($this instanceof GridFieldPage) {
-			return $this;
+        } elseif ($this instanceof GridFieldPage) {
+            return $this;
 
-		} else {
-			// Shouldn't happen but in case someone silly incorporates this trait in the wrong context ;)
-			return GridFieldPage::create();
-		}
-	}
+        } else {
+            // Shouldn't happen but in case someone silly incorporates this trait in the wrong context ;)
+            return GridFieldPage::create();
+        }
+    }
 
-	/**
-	 * add an arrow-overlay to this page's icon when open in the CMS
-	 */
-	public function getTreeTitle() {
-		return str_replace(
-			'jstree-pageicon',
-			'jstree-pageicon gridfieldpage-overlay',
-			$this->getGridFieldPage()->getTreeTitle());
-	}
+    /**
+     * add an arrow-overlay to this page's icon when open in the CMS
+     */
+    public function getTreeTitle()
+    {
+        return str_replace(
+            'jstree-pageicon',
+            'jstree-pageicon gridfieldpage-overlay',
+            $this->getGridFieldPage()->getTreeTitle());
+    }
 
-	/*
+    /*
 	 * Display status in the CMS grid
 	 */
-	public function getStatus($cached = true) {
+    public function getStatus($cached = true)
+    {
 
-		$status = null;
-		$statusflag = null;
-		$page = $this->getGridFieldPage();
+        $status = null;
+        $statusflag = null;
+        $page = $this->getGridFieldPage();
 
 
-		if($page->hasMethod("isPublished")) {
+        if ($page->hasMethod("isPublished")) {
 
-			$published = $page->isPublished();
+            $published = $page->isPublished();
 
-			if($published) {
-				$status = _t(
-					"GridFieldPage.StatusPublished",
-					'<i class="btn-icon btn-icon-accept"></i> Published on {date}',
-					"State for when a post is published.",
-					array(
-						"date" => $page->dbObject("LastEdited")->Nice()
-					)
-				);
-				//$status = 'Published';
+            if ($published) {
+                $status = _t(
+                    "GridFieldPage.StatusPublished",
+                    '<i class="btn-icon btn-icon-accept"></i> Published on {date}',
+                    "State for when a post is published.",
+                    array(
+                        "date" => $page->dbObject("LastEdited")->Nice()
+                    )
+                );
+                //$status = 'Published';
 
-				// Special case where sortorder changed
-				$liveRecord = Versioned::get_by_stage(get_class($page), 'Live')->byID($page->ID);
-				//return $page->Sort . ' - ' . $liveRecord->Sort;
-				if($liveRecord->Sort && $liveRecord->Sort != $page->Sort){
-					// override published status
-					$status = _t(
-						"GridFieldPage.StatusDraftReordered",
-						'<i class="btn-icon btn-icon-arrow-circle-double"></i> Draft modified (reordered)',
-						"State for when a page has been reordered."
-					);
-					//$status = 'Draft modified (reordered)';
-				}
+                // Special case where sortorder changed
+                $liveRecord = Versioned::get_by_stage(get_class($page), 'Live')->byID($page->ID);
+                //return $page->Sort . ' - ' . $liveRecord->Sort;
+                if ($liveRecord->Sort && $liveRecord->Sort != $page->Sort) {
+                    // override published status
+                    $status = _t(
+                        "GridFieldPage.StatusDraftReordered",
+                        '<i class="btn-icon btn-icon-arrow-circle-double"></i> Draft modified (reordered)',
+                        "State for when a page has been reordered."
+                    );
+                    //$status = 'Draft modified (reordered)';
+                }
 
-				// Special case where deleted from draft
-				if($page->IsDeletedFromStage) {
-					// override published status
-					$statusflag = "<span class='modified'>"
-						. _t("GridFieldPage.StatusDraftDeleted", "draft deleted") . "</span>";
-					//$status = 'Draft deleted';
-				}
+                // Special case where deleted from draft
+                if ($page->IsDeletedFromStage) {
+                    // override published status
+                    $statusflag = "<span class='modified'>"
+                        . _t("GridFieldPage.StatusDraftDeleted", "draft deleted") . "</span>";
+                    //$status = 'Draft deleted';
+                }
 
-				// If modified on stage, add
-				if($page->IsModifiedOnStage) {
-					// add to published status
-					$statusflag = "<span class='modified'>"
-						. _t("GridFieldPage.StatusModified", "draft modified") . "</span>";
-					//$status = 'Draft modified';
-				}
+                // If modified on stage, add
+                if ($page->IsModifiedOnStage) {
+                    // add to published status
+                    $statusflag = "<span class='modified'>"
+                        . _t("GridFieldPage.StatusModified", "draft modified") . "</span>";
+                    //$status = 'Draft modified';
+                }
 
-				// If same on stage...
-				if($page->IsSameOnStage) {
-					// leave as is
-				}
+                // If same on stage...
+                if ($page->IsSameOnStage) {
+                    // leave as is
+                }
 
-			} else {
-				if($page->IsAddedToStage) {
-					$status = _t(
-						"GridFieldPage.StatusDraft",
-						'<i class="btn-icon btn-icon-pencil"></i> Saved as Draft on {date}',
-						"State for when a post is saved but not published.",
-						array(
-							"date" => $page->dbObject("LastEdited")->Nice()
-						)
-					);
-					//$status = 'Draft';
-				}
+            } else {
+                if ($page->IsAddedToStage) {
+                    $status = _t(
+                        "GridFieldPage.StatusDraft",
+                        '<i class="btn-icon btn-icon-pencil"></i> Saved as Draft on {date}',
+                        "State for when a post is saved but not published.",
+                        array(
+                            "date" => $page->dbObject("LastEdited")->Nice()
+                        )
+                    );
+                    //$status = 'Draft';
+                }
 
-			}
+            }
 
-		}
+        }
 
-		// allow for extensions
-		$page->extend('updateStatus', $status, $statusflag);
-		return DBField::create_field('HTMLVarchar', $status.$statusflag);
-	}
+        // allow for extensions
+        $page->extend('updateStatus', $status, $statusflag);
+        return DBField::create_field('HTMLVarchar', $status . $statusflag);
+    }
 
 }


### PR DESCRIPTION
Bringing up to standards, adhering to `.editorconfig` and those silly open brackets on new lines after methods 🤔 

Also fixing an apparent bug in `->setAddDefaultGridField()` typehinting SilverStripe 3.x's database field class type `Boolean` instead of typecasting using PHP's native `(bool)` (scalar type hints not allowed pre-PHP7 anyway).